### PR TITLE
🔥 deleted UnorderdedListItem because it was not needed anymore

### DIFF
--- a/packages/next-templates/src/components/ExampleFooter/ExampleFooter.tsx
+++ b/packages/next-templates/src/components/ExampleFooter/ExampleFooter.tsx
@@ -1,7 +1,7 @@
 import Logo from '../../app/styling/assets/voorbeeld-footer.svg';
 import { NavigationList } from '../NavigationList/Navigationlist';
 import { NavigationListItem } from '../NavigationList/NavigationListIItem';
-import { Heading5, PageFooter, Paragraph, UnorderedList, UnorderedListItem } from '@utrecht/component-library-react';
+import { Heading5, PageFooter, Paragraph } from '@utrecht/component-library-react';
 import React, { HTMLAttributes } from 'react';
 import './footer.css';
 
@@ -24,12 +24,12 @@ export const ExampleFooter = ({ ...props }: ExampleFooterProps) => (
         <NavigationListItem className="utrecht-link-list__item" href="example.com" label="example" />
         <NavigationListItem className="utrecht-link-list__item" href="example.com" label="example" />
       </NavigationList>
-      <div>
+      <section>
         <Heading5>Heading</Heading5>
         <Paragraph className="utrecht-link-list__item">
           Lorem ipsum dolor sit amet, consectetur ad * isicing elit, sed do eiusmod *
         </Paragraph>
-      </div>
+      </section>
     </div>
   </PageFooter>
 );

--- a/packages/next-templates/src/components/ExampleFooter/ExampleFooter.tsx
+++ b/packages/next-templates/src/components/ExampleFooter/ExampleFooter.tsx
@@ -1,7 +1,7 @@
 import Logo from '../../app/styling/assets/voorbeeld-footer.svg';
 import { NavigationList } from '../NavigationList/Navigationlist';
 import { NavigationListItem } from '../NavigationList/NavigationListIItem';
-import { Heading5, PageFooter, Paragraph, UnorderedList } from '@utrecht/component-library-react';
+import { Heading5, PageFooter, Paragraph, UnorderedList, UnorderedListItem } from '@utrecht/component-library-react';
 import React, { HTMLAttributes } from 'react';
 import './footer.css';
 
@@ -24,12 +24,12 @@ export const ExampleFooter = ({ ...props }: ExampleFooterProps) => (
         <NavigationListItem className="utrecht-link-list__item" href="example.com" label="example" />
         <NavigationListItem className="utrecht-link-list__item" href="example.com" label="example" />
       </NavigationList>
-      <UnorderedList>
+      <div>
         <Heading5>Heading</Heading5>
         <Paragraph className="utrecht-link-list__item">
           Lorem ipsum dolor sit amet, consectetur ad * isicing elit, sed do eiusmod *
         </Paragraph>
-      </UnorderedList>
+      </div>
     </div>
   </PageFooter>
 );

--- a/packages/next-templates/src/components/ExampleFooter/ExampleFooter.tsx
+++ b/packages/next-templates/src/components/ExampleFooter/ExampleFooter.tsx
@@ -1,7 +1,7 @@
 import Logo from '../../app/styling/assets/voorbeeld-footer.svg';
 import { NavigationList } from '../NavigationList/Navigationlist';
 import { NavigationListItem } from '../NavigationList/NavigationListIItem';
-import { Heading5, PageFooter, Paragraph, UnorderedList, UnorderedListItem } from '@utrecht/component-library-react';
+import { Heading5, PageFooter, Paragraph, UnorderedList } from '@utrecht/component-library-react';
 import React, { HTMLAttributes } from 'react';
 import './footer.css';
 

--- a/packages/next-templates/src/components/ExampleFooter/ExampleFooterFocus/ExampleFooterFocus.tsx
+++ b/packages/next-templates/src/components/ExampleFooter/ExampleFooterFocus/ExampleFooterFocus.tsx
@@ -1,5 +1,5 @@
 import Logo from '../../app/styling/assets/voorbeeld-footer.svg';
-import { Heading5, PageFooter, Paragraph, UnorderedList, UnorderedListItem } from '@utrecht/component-library-react';
+import { Heading5, PageFooter, Paragraph, UnorderedList } from '@utrecht/component-library-react';
 import React, { HTMLAttributes } from 'react';
 import './footer.css';
 

--- a/packages/next-templates/src/components/ExampleFooter/ExampleFooterFocus/ExampleFooterFocus.tsx
+++ b/packages/next-templates/src/components/ExampleFooter/ExampleFooterFocus/ExampleFooterFocus.tsx
@@ -1,5 +1,5 @@
 import Logo from '../../app/styling/assets/voorbeeld-footer.svg';
-import { Heading5, PageFooter, Paragraph, UnorderedList } from '@utrecht/component-library-react';
+import { Heading5, PageFooter, Paragraph } from '@utrecht/component-library-react';
 import React, { HTMLAttributes } from 'react';
 import './footer.css';
 
@@ -8,12 +8,12 @@ export const ExampleFooterFocus = ({ ...props }: ExampleFooterFocusProps) => (
   <PageFooter>
     <div className="example-link-list-container" {...props}>
       <Logo className="example--footer-logo" />
-      <UnorderedList>
+      <section>
         <Heading5>Heading</Heading5>
         <Paragraph className="utrecht-link-list__item">
           Lorem ipsum dolor sit amet, consectetur ad * isicing elit, sed do eiusmod *
         </Paragraph>
-      </UnorderedList>
+      </section>
     </div>
   </PageFooter>
 );


### PR DESCRIPTION
### Changes ### 

Made it a Section instead, so i deleted the div and the UnorderedList and UnorderdedListItem from the import and code.
in both ExampleFooter component and ExampleFooterFocus component



~Made it a div instead of the UnorderedList without the UnorderdedListItem~


-~I removed the UnorderdedListItem because the styling ruined the Lorem ipsum in the footer, the styling is perfect without the UnorderdedListItem and with the UnorderedList~


~Is this 🤮 or can this be condoned?~ 



