### PR TITLE
Example footer focus import fix

### DIFF
--- a/packages/next-templates/src/app/layout.tsx
+++ b/packages/next-templates/src/app/layout.tsx
@@ -2,7 +2,6 @@ import './globals.css';
 import '@utrecht/component-library-css';
 import '@utrecht/design-tokens/dist/index.css';
 import type { Metadata } from 'next';
-import '@utrecht/component-library-css';
 import '@nl-design-system-unstable/voorbeeld-design-tokens/dist/index.css';
 import React from 'react';
 

--- a/packages/next-templates/src/app/mees/conformation-found/page.tsx
+++ b/packages/next-templates/src/app/mees/conformation-found/page.tsx
@@ -10,8 +10,6 @@ import {
   Paragraph,
   Separator,
 } from '@utrecht/component-library-react';
-import '@utrecht/component-library-css';
-import '@utrecht/design-tokens/dist/index.css';
 import { ExampleFooter } from '@/components/ExampleFooter/ExampleFooter';
 export default function Home() {
   return (

--- a/packages/next-templates/src/app/mees/conformation-lost/page.tsx
+++ b/packages/next-templates/src/app/mees/conformation-lost/page.tsx
@@ -11,8 +11,6 @@ import {
   Separator,
 } from '@utrecht/component-library-react';
 import { ExampleFooter } from '@/components/ExampleFooter/ExampleFooter';
-import '@utrecht/component-library-css';
-import '@utrecht/design-tokens/dist/index.css';
 
 export default function Home() {
   return (

--- a/packages/next-templates/src/app/mees/form-found/page.tsx
+++ b/packages/next-templates/src/app/mees/form-found/page.tsx
@@ -15,8 +15,8 @@ import {
   Textarea,
   Textbox,
 } from '@utrecht/component-library-react';
-import { ExampleFooter } from '@/components/ExampleFooter/ExampleFooter';
 import { SubmitHandler, useForm } from 'react-hook-form';
+import { ExampleFooterFocus } from '@/components/ExampleFooter/ExampleFooterFocus/ExampleFooterFocus';
 
 interface Inputs {
   Voornaam: string;
@@ -109,7 +109,7 @@ export default function Home() {
           </ButtonGroup>
         </form>
       </PageContent>
-      <ExampleFooter />
+      <ExampleFooterFocus />
     </Page>
   );
 }

--- a/packages/next-templates/src/app/mees/form-found/page.tsx
+++ b/packages/next-templates/src/app/mees/form-found/page.tsx
@@ -1,6 +1,4 @@
 'use client';
-import '@utrecht/component-library-css';
-import '@utrecht/design-tokens/dist/index.css';
 import {
   ButtonGroup,
   ButtonLink,

--- a/packages/next-templates/src/app/mees/form-lost/page.tsx
+++ b/packages/next-templates/src/app/mees/form-lost/page.tsx
@@ -1,6 +1,4 @@
 'use client';
-import '@utrecht/component-library-css';
-import '@utrecht/design-tokens/dist/index.css';
 import {
   ButtonGroup,
   ButtonLink,

--- a/packages/next-templates/src/app/mees/page.tsx
+++ b/packages/next-templates/src/app/mees/page.tsx
@@ -14,7 +14,6 @@ import {
   UnorderedListItem,
 } from '@utrecht/component-library-react';
 import '@utrecht/component-library-css';
-import '../../components/ExampleFooter/footer.css';
 import '@utrecht/design-tokens/dist/index.css';
 import { UtrechtIconArrow } from '@utrecht/web-component-library-react';
 import { ExampleFooter } from '@/components/ExampleFooter/ExampleFooter';

--- a/packages/next-templates/src/app/mees/page.tsx
+++ b/packages/next-templates/src/app/mees/page.tsx
@@ -13,8 +13,6 @@ import {
   UnorderedList,
   UnorderedListItem,
 } from '@utrecht/component-library-react';
-import '@utrecht/component-library-css';
-import '@utrecht/design-tokens/dist/index.css';
 import { UtrechtIconArrow } from '@utrecht/web-component-library-react';
 import { ExampleFooter } from '@/components/ExampleFooter/ExampleFooter';
 

--- a/packages/next-templates/src/components/ExampleFooter/ExampleFooterFocus/ExampleFooterFocus.tsx
+++ b/packages/next-templates/src/components/ExampleFooter/ExampleFooterFocus/ExampleFooterFocus.tsx
@@ -1,7 +1,7 @@
-import Logo from '../../app/styling/assets/voorbeeld-footer.svg';
+import Logo from '../../../app/styling/assets/voorbeeld-footer.svg';
 import { Heading5, PageFooter, Paragraph } from '@utrecht/component-library-react';
 import React, { HTMLAttributes } from 'react';
-import './footer.css';
+import '../footer.css';
 
 interface ExampleFooterFocusProps extends HTMLAttributes<HTMLDivElement> {}
 export const ExampleFooterFocus = ({ ...props }: ExampleFooterFocusProps) => (


### PR DESCRIPTION
### Changes  ### 

- when making the ExampleFooterFocus i took the ExampleFooter as base and Focus was in another directory, therefore the imports weren't working anymore, showing An error.
- Removed ExampleFooter CSS import because it comes with the component itself.
- ExampleFooterFocus successfully added to the Form-Found page.