### PR TITLE
💄 "NavigationItem now has a white underline instead of voorbeeld-color

### DIFF
--- a/packages/next-templates/src/components/NavigationList/Navigationlist.css
+++ b/packages/next-templates/src/components/NavigationList/Navigationlist.css
@@ -9,3 +9,7 @@
 
   line-height: 2em;
 }
+
+.utrecht-link {
+  --utrecht-link-text-decoration-color: white;
+}


### PR DESCRIPTION
### Changes ### 

- NavigationListItem now has a white underline instead of having the same colour as the footer therefore not visible