### PR TITLE
Mees voorbeeld theme form pagina styling

### DIFF
--- a/packages/next-templates/src/app/globals.css
+++ b/packages/next-templates/src/app/globals.css
@@ -68,12 +68,11 @@ https://www.figma.com/file/gX3fq7k0uUKC45AJbuItDv/Local---Voorbeeld---Bibliothee
   --utrecht-spotlight-section-padding-block-end: 24px;
 }
 
+/* HACK these tokens are not yet defined in voorbeeld-thema */
 .utrecht-radio-button {
   --utrecht-radio-button-background-color: white;
   --utrecht-radio-button-icon-size: 0%;
   --utrecht-radio-button-checked-border-width: 0.35em;
   --utrecht-radio-button-checked-border-color: var(--voorbeeld-color-violet-700);
   --utrecht-radio-button-border-color: #7a8aa0;
-
-  vertical-align: 0% !important;
 }

--- a/packages/next-templates/src/app/globals.css
+++ b/packages/next-templates/src/app/globals.css
@@ -67,3 +67,13 @@ https://www.figma.com/file/gX3fq7k0uUKC45AJbuItDv/Local---Voorbeeld---Bibliothee
   --utrecht-heading-2-font-size: 20px;
   --utrecht-spotlight-section-padding-block-end: 24px;
 }
+
+.utrecht-radio-button {
+  --utrecht-radio-button-background-color: white;
+  --utrecht-radio-button-icon-size: 0%;
+  --utrecht-radio-button-checked-border-width: 0.35em;
+  --utrecht-radio-button-checked-border-color: var(--voorbeeld-color-violet-700);
+  --utrecht-radio-button-border-color: #7a8aa0;
+
+  vertical-align: 0% !important;
+}

--- a/packages/next-templates/src/app/ryan/form/page.tsx
+++ b/packages/next-templates/src/app/ryan/form/page.tsx
@@ -123,6 +123,7 @@ export default function Home() {
                 })}
                 placeholder=""
               ></Textarea>
+              {/*Going to make this a component soon (ExampleBijlageToevoegen) everything between the Article */}
               <Article>
                 <Paragraph>Bijlage</Paragraph>
                 <Paragraph>(optioneel)</Paragraph>

--- a/packages/next-templates/src/app/ryan/form/page.tsx
+++ b/packages/next-templates/src/app/ryan/form/page.tsx
@@ -12,7 +12,6 @@ import {
   FormLabel,
   Heading2,
   Heading4,
-  Heading6,
   Link,
   Page,
   PageContent,
@@ -125,7 +124,7 @@ export default function Home() {
                 placeholder=""
               ></Textarea>
               <Article>
-                <Heading6>Bijlage</Heading6>
+                <Paragraph>Bijlage</Paragraph>
                 <Paragraph>(optioneel)</Paragraph>
                 <UnorderedList>
                   <UnorderedListItem>Bestanden moeten kleiner zijn dan 10 MB.</UnorderedListItem>

--- a/packages/next-templates/src/app/ryan/form/page.tsx
+++ b/packages/next-templates/src/app/ryan/form/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import {
+  Article,
+  Button,
   ButtonLink,
   Document,
   Fieldset,
@@ -10,6 +12,7 @@ import {
   FormLabel,
   Heading2,
   Heading4,
+  Heading6,
   Link,
   Page,
   PageContent,
@@ -19,6 +22,8 @@ import {
   SelectOption,
   Textarea,
   Textbox,
+  UnorderedList,
+  UnorderedListItem,
 } from '@utrecht/component-library-react';
 import { ExampleFooter } from '@/components/ExampleFooter/ExampleFooter';
 import { useForm } from 'react-hook-form';
@@ -119,7 +124,16 @@ export default function Home() {
                 })}
                 placeholder=""
               ></Textarea>
-              <Paragraph>{errors.description?.message}</Paragraph>
+              <Article>
+                <Heading6>Bijlage</Heading6>
+                <Paragraph>(optioneel)</Paragraph>
+                <UnorderedList>
+                  <UnorderedListItem>Bestanden moeten kleiner zijn dan 10 MB.</UnorderedListItem>
+                  <UnorderedListItem>Toegestane bestandstypen: gif, jpg, jpeg, png.</UnorderedListItem>
+                </UnorderedList>
+                <Button appearance="primary-action-button">Bestand kiezen</Button>
+                <Paragraph>Geen bestand gekozen</Paragraph>
+              </Article>
             </FormField>
             <Heading4>Op welke locatie heeft de melding betrekking?</Heading4>
             <FormField invalid={!!errors.place}>


### PR DESCRIPTION
### Changes  

- Radio Buttons are styled so that they look like the ones in Figma ( they are a bit small though)
- Made the "Bijlagen toeoegen" sectie in the form page 
- Added comment above "Bijlagen toeoegen" Going to make this a component because it needs custom styling 
- added comment above Radio Button styling that these tokens are not yet defined in Voorbeeld-theme