### PR TITLE
Form types adding

### DIFF
--- a/packages/next-templates/src/app/layout.tsx
+++ b/packages/next-templates/src/app/layout.tsx
@@ -3,7 +3,7 @@ import '@utrecht/design-tokens/dist/index.css';
 import type { Metadata } from 'next';
 import '@nl-design-system-unstable/voorbeeld-design-tokens/dist/index.css';
 import './globals.css';
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import './font';
 
 export const metadata: Metadata = {
@@ -11,11 +11,13 @@ export const metadata: Metadata = {
   description: 'Demo van Utrecht formulieren voor verschillende services',
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({ children }: PropsWithChildren<{}>) {
   return (
     <html lang="nl">
       {/* <body className="voorbeeld-theme">{children}</body> */}
-      <body className="voorbeeld-theme">{children}</body>
+      <body className="voorbeeld-theme">
+        <div className="utrecht-document">{children}</div>
+      </body>
     </html>
   );
 }

--- a/packages/next-templates/src/app/ryan/form/page.tsx
+++ b/packages/next-templates/src/app/ryan/form/page.tsx
@@ -221,7 +221,7 @@ export default function Home() {
                 <FormLabel htmlFor="Email">E-mail</FormLabel>
               </Paragraph>
               <Paragraph>
-                <Textbox autoComplete="email" id="Email" name="Email" type="text" />
+                <Textbox autoComplete="email" id="Email" name="Email" type="email" />
               </Paragraph>
             </FormField>
             <FormField type="text">
@@ -229,7 +229,7 @@ export default function Home() {
                 <FormLabel htmlFor="Telefoon">Telefoon</FormLabel>
               </Paragraph>
               <Paragraph>
-                <Textbox autoComplete="tel" id="Telefoon" name="Telefoon" type="text" />
+                <Textbox autoComplete="tel" id="Telefoon" name="Telefoon" type="tel" />
               </Paragraph>
             </FormField>
             <ButtonLink appearance="primary-action-button">Versturen</ButtonLink>


### PR DESCRIPTION
### Changes

- The "Type" attribute in the Textbox now corresponds to the Type. For example, a Textbox for an Email now has type="Email" instead of type="text".

- In Layout.tsx, there is now a div in the body with the classname utrecht-document to replicate a document. This change is necessary because a Utrecht Document component can only be rendered on the client side, and that is not possible in Layout.tsx at the moment.